### PR TITLE
Switch to new proc_macro_derive semantics - original AST should not be emitted.

### DIFF
--- a/derive-new/src/lib.rs
+++ b/derive-new/src/lib.rs
@@ -16,7 +16,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
     let result = new_for_struct(ast);
 
-    format!("{}\n{}", input, result).parse().expect("couldn't parse string to tokens")
+    result.to_string().parse().expect("couldn't parse string to tokens")
 }
 
 fn new_for_struct(ast: syn::MacroInput) -> quote::Tokens {


### PR DESCRIPTION
Fixes #9

---

Tested against a local rust build since there's no released nightly with the change yet.