### PR TITLE
Fix the Cargo.toml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Cargo.toml:
 
 ```
 [dependencies]
-derive-new = 0.3
+derive-new = "0.3"
 ```
 
 Rust code:


### PR DESCRIPTION
It expects a string for the version, not a float value.