### PR TITLE
Drop #feature directive

### DIFF
--- a/derive-new/src/lib.rs
+++ b/derive-new/src/lib.rs
@@ -1,5 +1,4 @@
 #![crate_type = "proc-macro"]
-#![feature(proc_macro, proc_macro_lib)]
 
 extern crate proc_macro;
 extern crate syn;


### PR DESCRIPTION
proc_macro is stable in current beta and nightly and will be stable
in 1.15.0 released tomorrow.
Dropping this will allow us to build with rust stable once it's released.

Also fixes #14