### PR TITLE
Propagate lint attributes from the parent item to the constructors

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,3 +1,5 @@
+#![deny(non_snake_case)]
+
 #[macro_use]
 extern crate derive_new;
 
@@ -275,3 +277,11 @@ fn test_more_involved_enum() {
     let x = Enterprise::<u8>::new_spock(42);
     assert_eq!(x, Enterprise::Spock { x: PhantomData, y: 42 });
 }
+
+#[allow(non_snake_case)]
+#[derive(new, PartialEq, Debug)]
+pub struct Upside { X: i32 }
+
+#[cfg_attr(test, allow(non_snake_case))]
+#[derive(new, PartialEq, Debug)]
+pub struct Down { X: i32 }


### PR DESCRIPTION
Ok, one more :) Now there should be no outstanding issues left other than releasing 1.0.

This propagates these types of attrs from the body to the ctors:
- `#[allow(..)]`
- `#[deny(..)]`
- `#[forbid(..)]`
- `#[warn(..)]`
- `#[cfg_attr(.., allow(..))]`
- `#[cfg_attr(.., deny(..))]`
- `#[cfg_attr(.., forbid(..))]`
- `#[cfg_attr(.., warn(..))]`

Closes #13.

@nrc @Arnavion @dtolnay 