### PR TITLE
Skip panic check on attributes other than '#[new]'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,10 @@ impl FieldAttr {
             };
             let list = match meta {
                 Meta::List(l) => l,
-                _ => panic!("Invalid #[new] attribute, expected #[new(..)]"),
+                _ if meta.name() == "new" => {
+                    panic!("Invalid #[new] attribute, expected #[new(..)]");
+                }
+                _ => continue,
             };
             if result.is_some() {
                 panic!("Expected at most one #[new] attribute");


### PR DESCRIPTION
I think that the last commit accidentally removed this check.

Closes #31.