### PR TITLE
Ignore unrelated field attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,3 @@ proc-macro = true
 proc-macro2 = "0.3"
 quote = "0.5"
 syn = "0.13"
-
-[workspace]
-members = ["testcrate"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ proc-macro = true
 proc-macro2 = "0.3"
 quote = "0.5"
 syn = "0.13"
+
+[workspace]
+members = ["testcrate"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,15 +265,18 @@ impl FieldAttr {
                 AttrStyle::Outer => {}
                 _ => continue,
             }
+            let last_attr_path = attr.path.segments.iter().last()
+                .expect("Expected at least one segment where #[segment[::segment*](..)]");
+            if (*last_attr_path).ident.as_ref() != "new" {
+                continue
+            }
             let meta = match attr.interpret_meta() {
                 Some(meta) => meta,
                 None => continue,
             };
             let list = match meta {
                 Meta::List(l) => l,
-                _ if meta.name() == "new" => {
-                    panic!("Invalid #[new] attribute, expected #[new(..)]");
-                }
+                _ if meta.name() == "new" => panic!("Invalid #[new] attribute, expected #[new(..)]"),
                 _ => continue,
             };
             if result.is_some() {

--- a/testcrate/Cargo.toml
+++ b/testcrate/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 derive-new = { path = ".." }
 
 [dev-dependencies]
-compiletest_rs = "0.3.7"
+compiletest_rs = { version = "0.3.10", features = ["stable"] }
 
 [[test]]
 name = "compile-fail"

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -285,3 +285,9 @@ pub struct Upside { X: i32 }
 #[cfg_attr(test, allow(non_snake_case))]
 #[derive(new, PartialEq, Debug)]
 pub struct Down { X: i32 }
+
+#[derive(new, PartialEq, Debug)]
+pub struct All {
+    #[allow(missing_docs)]
+    pub x: i32
+}


### PR DESCRIPTION
Currently all attributes on fields are parsed by derive-new. This change updates the attribute parsing logic to ignore any attribute that aren't specifically for derive-new. For example, previously:

```rust
#[derive(new)]
pub struct All {
    #[allow(missing_docs)]
    pub x: i32
}
```

Would result in the following error:

> error: proc-macro derive panicked
>    --> tests\test.rs:289:10
>     |
> 289 | #[derive(new, PartialEq, Debug)]
>     |          ^^^
>     |
>     = help: message: Invalid #[new] attribute: #[new(missing_docs)]

The revision of compiletest was updated to allow all tests to build on stable. It might be a good idea to configure the CI to use the minimum supported version of Rust to execute tests.

Additionally, I was having issues building tests due to the workspace configuration and syn::Generics. I didn't look into it much, but removed the workspace configuration so it wouldn't affect others.