### PR TITLE
Fix Travis CI nightly build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
     - rust: nightly
       script:
         - cargo test
+        - rm target/debug/deps/libderive_new-*.so
         - cargo test --manifest-path testcrate/Cargo.toml
 
 script:


### PR DESCRIPTION
That was easier than I thought: https://travis-ci.org/hcpl/derive-new/builds/382464446.

Also, would you mind if I added a Rust 1.15 build? The README makes it sound like `derive-new` should work in every Rust version that has stable `#[derive]` which means every version since 1.15.