### PR TITLE
Option to make constructor `const`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,12 +162,48 @@ fn new_for_enum(ast: &syn::DeriveInput, data: &syn::DataEnum) -> proc_macro2::To
     my_quote!(#(#impls)*)
 }
 
+fn parse_derive_new_attr(attrs: &[syn::Attribute]) -> bool {
+    let mut is_const = false;
+
+    for i in attrs {
+        if let Ok(meta) = i.parse_meta() {
+            if !meta.path().is_ident("new") {
+                continue;
+            }
+            let list = match meta {
+                syn::Meta::List(l) => l,
+                _ => panic!("Invalid #[new] attribute, expected #[new(..)]")
+            };
+            for item in list.nested.iter() {
+                match *item {
+                    syn::NestedMeta::Meta(syn::Meta::Path(ref path)) => {
+                        if path.is_ident("const") {
+                            is_const = true;
+                            continue;
+                        }
+                    }
+                    _ => {},
+                }
+                panic!("Invalid #[new] attribute");
+            }
+        }
+    }
+
+    is_const
+}
+
 fn new_impl(
     ast: &syn::DeriveInput,
     fields: Option<&syn::punctuated::Punctuated<syn::Field, Token![,]>>,
     named: bool,
     variant: Option<&syn::Ident>,
 ) -> proc_macro2::TokenStream {
+    let is_const = parse_derive_new_attr(&ast.attrs);
+    let const_opt = if is_const {
+        my_quote!(const)
+    } else {
+        my_quote!()
+    };
     let name = &ast.ident;
     let unit = fields.is_none();
     let empty = Default::default();
@@ -209,7 +245,7 @@ fn new_impl(
         impl #impl_generics #name #ty_generics #where_clause {
             #[doc = #doc]
             #lint_attrs
-            pub fn #new(#(#args),*) -> Self {
+            pub #const_opt fn #new(#(#args),*) -> Self {
                 #name #qual #inits
             }
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -32,6 +32,16 @@ pub struct Bar {
     pub y: String,
 }
 
+#[derive(new)]
+#[new(const)]
+struct ConstFoo {
+    pub x: u8,
+    pub y: u8,
+    pub z: u8,
+}
+
+const CONST_FOO: ConstFoo = ConstFoo::new(1, 2, 3);
+
 #[test]
 fn test_simple_struct() {
     let x = Bar::new(42, "Hello".to_owned());


### PR DESCRIPTION
It's sometimes convenient for a constructor to be a `const fn`.

Compiling the unit test here fails with:

```rust
   Compiling derive-new v0.5.9 (/home/ian/src/derive-new)
error[E0659]: `new` is ambiguous (derive helper attribute vs any other name)
  --> tests/test.rs:36:3
   |
36 | #[new(const)]
   |   ^^^ ambiguous name
   |
note: `new` could refer to the derive helper attribute defined here
  --> tests/test.rs:35:10
   |
35 | #[derive(new)]
   |          ^^^
note: `new` could also refer to the derive macro imported here
  --> tests/test.rs:3:1
   |
3  | #[macro_use]
   | ^^^^^^^^^^^^
```

Not sure how to solve that. I guess not using the same name `new` for both...

I guess if that can be addressed, this should also have documentation, and work with enums. Anyway, I thought I might as well open a draft PR with the code I have for now.