### PR TITLE
Remove unnecessary uses of cfg!(feature = std)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,13 +253,7 @@ enum FieldAttr {
 impl FieldAttr {
     pub fn as_tokens(&self) -> proc_macro2::TokenStream {
         match *self {
-            FieldAttr::Default => {
-                if cfg!(feature = "std") {
-                    my_quote!(::std::default::Default::default())
-                } else {
-                    my_quote!(::core::default::Default::default())
-                }
-            }
+            FieldAttr::Default => my_quote!(::core::default::Default::default()),
             FieldAttr::Value(ref s) => my_quote!(#s),
         }
     }
@@ -385,11 +379,7 @@ impl<'a> FieldExt<'a> {
     pub fn as_init(&self) -> proc_macro2::TokenStream {
         let f_name = &self.ident;
         let init = if self.is_phantom_data() {
-            if cfg!(feature = "std") {
-                my_quote!(::std::marker::PhantomData)
-            } else {
-                my_quote!(::core::marker::PhantomData)
-            }
+            my_quote!(::core::marker::PhantomData)
         } else {
             match self.attr {
                 None => my_quote!(#f_name),


### PR DESCRIPTION
The `core` module is present even in non-`no_std` builds, so there's no reason to generate `::std` versions of the relevant code.