### PR TITLE
implement `into` and `into_iter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,33 @@ struct Foo {
 let _ = Foo::new(true);
 ```
 
+To make type conversion easier, `#[new(into)]` attribute changes the parameter type
+to `impl Into<T>`, and populates the field with `value.into()`:
+
+```rust
+#[derive(new)]
+struct Foo {
+    #[new(into)]
+    x: String,
+}
+
+let _ = Foo::new("Hello");
+```
+
+For iterators/collections, `#[new(into_iter = "T")]` attribute changes the parameter type
+to `impl IntoIterator<Item = T>`, and populates the field with `value.into_iter().collect()`:
+
+```rust
+#[derive(new)]
+struct Foo {
+    #[new(into_iter = "bool")]
+    x: Vec<bool>,
+}
+
+let _ = Foo::new([true, false]);
+let _ = Foo::new(Some(true));
+```
+
 Generic types are supported; in particular, `PhantomData<T>` fields will be not
 included in the argument list and will be initialized automatically:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,33 @@
 //! }
 //! ```
 //!
+//! To make type conversion easier, `#[new(into)]` attribute changes the parameter type
+//! to `impl Into<T>`, and populates the field with `value.into()`:
+//!
+//! ```rust
+//! #[derive(new)]
+//! struct Foo {
+//!     #[new(into)]
+//!     x: String,
+//! }
+//!
+//! let _ = Foo::new("Hello");
+//! ```
+//!
+//! For iterators/collections, `#[new(into_iter = "T")]` attribute changes the parameter type
+//! to `impl IntoIterator<Item = T>`, and populates the field with `value.into_iter().collect()`:
+//!
+//! ```rust
+//! #[derive(new)]
+//! struct Foo {
+//!     #[new(into_iter = "bool")]
+//!     x: Vec<bool>,
+//! }
+//!
+//! let _ = Foo::new([true, false]);
+//! let _ = Foo::new(Some(true));
+//! ```
+//!
 //! Generic types are supported; in particular, `PhantomData<T>` fields will be not
 //! included in the argument list and will be initialized automatically:
 //!
@@ -181,7 +208,7 @@ fn new_impl(
         .enumerate()
         .map(|(i, f)| FieldExt::new(f, i, named))
         .collect();
-    let args = fields.iter().filter(|f| f.needs_arg()).map(|f| f.as_arg());
+    let args = fields.iter().filter_map(|f| f.as_arg());
     let inits = fields.iter().map(|f| f.as_init());
     let inits = if unit {
         my_quote!()
@@ -254,13 +281,19 @@ fn collect_parent_lint_attrs(attrs: &[syn::Attribute]) -> Vec<syn::Attribute> {
 
 enum FieldAttr {
     Default,
+    Into,
+    IntoIter(proc_macro2::TokenStream),
     Value(proc_macro2::TokenStream),
 }
 
 impl FieldAttr {
-    pub fn as_tokens(&self) -> proc_macro2::TokenStream {
+    pub fn as_tokens(&self, name: &syn::Ident) -> proc_macro2::TokenStream {
         match *self {
             FieldAttr::Default => my_quote!(::core::default::Default::default()),
+            FieldAttr::Into => my_quote!(::core::convert::Into::into(#name)),
+            FieldAttr::IntoIter(_) => {
+                my_quote!(::core::iter::Iterator::collect(::core::iter::IntoIterator::into_iter(#name)))
+            }
             FieldAttr::Value(ref s) => my_quote!(#s),
         }
     }
@@ -295,33 +328,39 @@ impl FieldAttr {
                 .unwrap_or_else(|err| panic!("Invalid #[new] attribute: {}", err))
             {
                 match item {
-                    syn::Meta::Path(path) => {
-                        if path.is_ident("default") {
+                    syn::Meta::Path(path) => match path.get_ident() {
+                        Some(ident) if ident == "default" => {
                             result = Some(FieldAttr::Default);
-                        } else {
-                            panic!(
-                                "Invalid #[new] attribute: #[new({})]",
-                                path_to_string(&path)
-                            );
                         }
-                    }
+                        Some(ident) if ident == "into" => {
+                            result = Some(FieldAttr::Into);
+                        }
+                        _ => panic!(
+                            "Invalid #[new] attribute: #[new({})]",
+                            path_to_string(&path)
+                        ),
+                    },
                     syn::Meta::NameValue(kv) => {
                         if let syn::Expr::Lit(syn::ExprLit {
                             lit: syn::Lit::Str(ref s),
                             ..
                         }) = kv.value
                         {
-                            if kv.path.is_ident("value") {
-                                let tokens = lit_str_to_token_stream(s).ok().expect(&format!(
-                                    "Invalid expression in #[new]: `{}`",
-                                    s.value()
-                                ));
-                                result = Some(FieldAttr::Value(tokens));
-                            } else {
-                                panic!(
+                            let tokens = lit_str_to_token_stream(s)
+                                .ok()
+                                .expect(&format!("Invalid expression in #[new]: `{}`", s.value()));
+
+                            match kv.path.get_ident() {
+                                Some(ident) if ident == "into_iter" => {
+                                    result = Some(FieldAttr::IntoIter(tokens));
+                                }
+                                Some(ident) if ident == "value" => {
+                                    result = Some(FieldAttr::Value(tokens));
+                                }
+                                _ => panic!(
                                     "Invalid #[new] attribute: #[new({} = ..)]",
                                     path_to_string(&kv.path)
-                                );
+                                ),
                             }
                         } else {
                             panic!("Non-string literal value in #[new] attribute");
@@ -361,10 +400,6 @@ impl<'a> FieldExt<'a> {
         }
     }
 
-    pub fn has_attr(&self) -> bool {
-        self.attr.is_some()
-    }
-
     pub fn is_phantom_data(&self) -> bool {
         match *self.ty {
             syn::Type::Path(syn::TypePath {
@@ -379,14 +414,23 @@ impl<'a> FieldExt<'a> {
         }
     }
 
-    pub fn needs_arg(&self) -> bool {
-        !self.has_attr() && !self.is_phantom_data()
-    }
+    pub fn as_arg(&self) -> Option<proc_macro2::TokenStream> {
+        if self.is_phantom_data() {
+            return None;
+        }
 
-    pub fn as_arg(&self) -> proc_macro2::TokenStream {
-        let f_name = &self.ident;
+        let ident = &self.ident;
         let ty = &self.ty;
-        my_quote!(#f_name: #ty)
+
+        match self.attr {
+            Some(FieldAttr::Default) => None,
+            Some(FieldAttr::Into) => Some(my_quote!(#ident: impl ::core::convert::Into<#ty>)),
+            Some(FieldAttr::IntoIter(ref s)) => {
+                Some(my_quote!(#ident: impl ::core::iter::IntoIterator<Item = #s>))
+            }
+            Some(FieldAttr::Value(_)) => None,
+            None => Some(my_quote!(#ident: #ty)),
+        }
     }
 
     pub fn as_init(&self) -> proc_macro2::TokenStream {
@@ -396,7 +440,7 @@ impl<'a> FieldExt<'a> {
         } else {
             match self.attr {
                 None => my_quote!(#f_name),
-                Some(ref attr) => attr.as_tokens(),
+                Some(ref attr) => attr.as_tokens(f_name),
             }
         };
         if self.named {

--- a/testcrate/tests/compile-fail/enum-with-discriminants.rs
+++ b/testcrate/tests/compile-fail/enum-with-discriminants.rs
@@ -8,3 +8,5 @@ enum Enum {
     Foo,
     Bar = 42,
 }
+
+fn main() {}

--- a/testcrate/tests/compile-fail/enum-zero-variants.rs
+++ b/testcrate/tests/compile-fail/enum-zero-variants.rs
@@ -5,3 +5,5 @@ extern crate derive_new;
 //~^ ERROR proc-macro derive
 //~^^ HELP #[derive(new)] cannot be implemented for enums with zero variants
 enum Enum {}
+
+fn main() {}

--- a/testcrate/tests/compile-fail/multiple-new-attrs.rs
+++ b/testcrate/tests/compile-fail/multiple-new-attrs.rs
@@ -10,3 +10,5 @@ struct Foo {
     #[new(value = "42")]
     y: i32,
 }
+
+fn main() {}

--- a/testcrate/tests/compile-fail/new-invalid-attr-type.rs
+++ b/testcrate/tests/compile-fail/new-invalid-attr-type.rs
@@ -8,3 +8,5 @@ struct Foo {
     #[new = "foo"]
     x: i32,
 }
+
+fn main() {}

--- a/testcrate/tests/compile-fail/new-invalid-value.rs
+++ b/testcrate/tests/compile-fail/new-invalid-value.rs
@@ -5,6 +5,8 @@ extern crate derive_new;
 //~^ ERROR produced unparsable tokens
 struct Foo {
     #[new(value = "hello@world")]
-//~^ ERROR expected one of
+    //~^ ERROR expected one of
     x: i32,
 }
+
+fn main() {}

--- a/testcrate/tests/compile-fail/new-list-invalid.rs
+++ b/testcrate/tests/compile-fail/new-list-invalid.rs
@@ -8,3 +8,5 @@ struct Foo {
     #[new(foo)]
     x: i32,
 }
+
+fn main() {}

--- a/testcrate/tests/compile-fail/new-name-value-invalid.rs
+++ b/testcrate/tests/compile-fail/new-name-value-invalid.rs
@@ -8,3 +8,5 @@ struct Foo {
     #[new(foo = "bar")]
     x: i32,
 }
+
+fn main() {}

--- a/testcrate/tests/compile-fail/new-nested-list.rs
+++ b/testcrate/tests/compile-fail/new-nested-list.rs
@@ -8,3 +8,5 @@ struct Foo {
     #[new(foo("bar"))]
     x: i32,
 }
+
+fn main() {}

--- a/testcrate/tests/compile-fail/new-nested-literal.rs
+++ b/testcrate/tests/compile-fail/new-nested-literal.rs
@@ -3,8 +3,10 @@ extern crate derive_new;
 
 #[derive(new)]
 //~^ ERROR proc-macro derive
-//~^^ HELP Invalid #[new] attribute: literal value in #[new(..)]
+//~^^ HELP Invalid #[new] attribute: expected identifier
 struct Foo {
     #[new("foo")]
     x: i32,
 }
+
+fn main() {}

--- a/testcrate/tests/compile-fail/new-non-literal-value.rs
+++ b/testcrate/tests/compile-fail/new-non-literal-value.rs
@@ -8,3 +8,5 @@ struct Foo {
     #[new(value = false)]
     x: i32,
 }
+
+fn main() {}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -170,7 +170,6 @@ fn test_struct_with_defaults() {
         pub z: T,
     }
 
-
     let x = Waldo::<Vec<String>>::new(42);
     assert_eq!(
         x,
@@ -226,7 +225,6 @@ fn test_struct_mixed_defaults() {
         }
     );
 }
-
 
 #[cfg(feature = "std")]
 #[test]
@@ -326,8 +324,8 @@ fn test_enum_unit_variants() {
 #[cfg(feature = "std")]
 #[test]
 fn test_more_involved_enum() {
-    use std::marker::PhantomData;
     use std::default::Default;
+    use std::marker::PhantomData;
 
     /// A more involved enum
     #[derive(new, PartialEq, Debug)]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -181,6 +181,49 @@ fn test_struct_with_defaults() {
     );
 }
 
+#[cfg(feature = "std")]
+#[test]
+fn test_struct_with_into() {
+    #[derive(new, PartialEq, Debug)]
+    pub struct Foo {
+        #[new(into)]
+        pub value: String,
+    }
+
+    assert_eq!(
+        Foo::new("bar"),
+        Foo {
+            value: "bar".to_string(),
+        }
+    );
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn test_struct_with_into_iter() {
+    #[derive(new, PartialEq, Debug)]
+    pub struct Foo {
+        #[new(into_iter = "bool")]
+        pub values: Vec<bool>,
+    }
+
+    assert_eq!(
+        Foo::new([true, false, true]),
+        Foo {
+            values: vec![true, false, true]
+        }
+    );
+
+    assert_eq!(
+        Foo::new(Some(false)),
+        Foo {
+            values: vec![false]
+        }
+    );
+
+    assert_eq!(Foo::new(None), Foo { values: vec![] });
+}
+
 /// A struct where fields have explicitly provided defaults.
 #[derive(new, PartialEq, Debug)]
 pub struct Fred {


### PR DESCRIPTION
Thank you for the awesome crate!
Here is a feature suggestion, that is sorely missed in our projects. It has also been requested twice already (#43 and #62).

## `#[new(into)]`

To make type conversion easier, `#[new(into)]` attribute changes the parameter type to `impl Into<T>`, and populates the field with `value.into()`. This is useful for containers like strings, accepting a `String` or a `&str`:

```rust
#[derive(new)]
struct Foo {
    #[new(into)]
    x: String,
}

let _ = Foo::new("Hello".to_string());
let _ = Foo::new(format!("Hello"));
let _ = Foo::new("Hello");
```

It is also useful for wrapping types like `Box<T>` and `Rc<T>`, without having to wrap at every callsite:

```rust
#[derive(new)]
struct Foo {
    #[new(into)]
    x: Rc<Bar>,
}

let _ = Foo::new(Rc::new(bar));
let _ = Foo::new(bar.into());
let _ = Foo::new(bar);
```

## `#[new(into_iter = "T")]`

For iterators/collections, `#[new(into_iter = "T")]` attribute changes the parameter type to `impl IntoIterator<Item = T>`, and populates the field with `value.into_iter().collect()`. This allows initializing with a variety of types, like `[T]`, `Option<T>`, `Vec<T>`, sets, maps, and even other iterators:

```rust
#[derive(new)]
struct Foo {
    #[new(into_iter = "bool")]
    x: Vec<bool>,
}

let _ = Foo::new(vec![true, false]);
let _ = Foo::new([true, false]);
let _ = Foo::new(Some(true));
```

## About this PR

I split this into three parts to make reviewing easier:

- https://github.com/nrc/derive-new/commit/08e5390e70001360691cabc82fec7d0523fada24 fixes broken integration tests (I suspect CI is out of date).
- https://github.com/nrc/derive-new/commit/3e310d9751e8db31519184e7623678adb6a76f5f fixes formatting for a couple of files (using the default `cargo fmt`).
- https://github.com/nrc/derive-new/commit/8f608804e3cb8752a0690003f93d822d3041a9ba implements the feature, adding tests, and documentation to both `README.md` and `lib.rs`.

Please let me know if I can do anything else.